### PR TITLE
Bug: Not working with Windows

### DIFF
--- a/src/doctest.js
+++ b/src/doctest.js
@@ -16,15 +16,22 @@ export default (filePath, options = {}) => {
   const file = fs.readFileSync(filePath, 'utf8')
   const doctests = parseDoctests(file)
   doctests.forEach((doctest, index) => {
+    console.log('inside')
     const { actual, expected } = evalDoctest(doctest, filePath, options.instance)
-
+    console.log('passing')
     if (actual.error) {
+      console.log('actual err')
+      console.log(actual)
       throw actual.error
     } else if (expected.error) {
+      console.log('expected err')
       throw expected.error
     } else {
+      console.log('else')
       const { testingFunction = defaultTestingFunction } = options
+      console.log('else passing')
       testingFunction(actual, expected, doctest, index)
+      console.log('else passed')
     }
   })
 }

--- a/src/doctest.js
+++ b/src/doctest.js
@@ -16,22 +16,14 @@ export default (filePath, options = {}) => {
   const file = fs.readFileSync(filePath, 'utf8')
   const doctests = parseDoctests(file)
   doctests.forEach((doctest, index) => {
-    console.log('inside')
     const { actual, expected } = evalDoctest(doctest, filePath, options.instance)
-    console.log('passing')
     if (actual.error) {
-      console.log('actual err')
-      console.log(actual)
       throw actual.error
     } else if (expected.error) {
-      console.log('expected err')
       throw expected.error
     } else {
-      console.log('else')
       const { testingFunction = defaultTestingFunction } = options
-      console.log('else passing')
       testingFunction(actual, expected, doctest, index)
-      console.log('else passed')
     }
   })
 }

--- a/src/doctest_parser.js
+++ b/src/doctest_parser.js
@@ -58,16 +58,16 @@ export default text => {
 
   // ignore multi-line comment start
   // this is a bit naive as it only uses spaces/indentation to cleanse
-  lexer.addRule(/\r\n\* /, () => {})
-  lexer.addRule(/\r\n \* /, () => {})
-  lexer.addRule(/\r\n  \* /, () => {})
-  lexer.addRule(/\r\n   \* /, () => {})
-  lexer.addRule(/\r\n    \* /, () => {})
-  lexer.addRule(/\r\n     \* /, () => {})
-  lexer.addRule(/\r\n      \* /, () => {})
+  lexer.addRule(/\n\* / && /\r\n\* /, () => {})
+  lexer.addRule(/\n \* / && /\r\n \* /, () => {})
+  lexer.addRule(/\n  \* / && /\r\n  \* /, () => {})
+  lexer.addRule(/\n   \* / && /\r\n   \* /, () => {})
+  lexer.addRule(/\n    \* / && /\r\n    \* /, () => {})
+  lexer.addRule(/\n     \* / && /\r\n     \* /, () => {})
+  lexer.addRule(/\n      \* / && /\r\n      \* /, () => {})
 
   // add chars to appropriate section
-  lexer.addRule(/\r\n|./, lexme => {
+  lexer.addRule(/\n|./ && /\r\n|./, lexme => {
     if (state === IN_EXAMPLE) {
       doctests[doctestIndex].resultString += lexme
     } else if (state === IN_RETURN_VALUE) {

--- a/src/doctest_parser.js
+++ b/src/doctest_parser.js
@@ -16,18 +16,13 @@ const grammar = {
 
 export default text => {
   // lexer parser setup
-  console.log(1)
   const lexer = new Lexer()
-  console.log(2)
   const parser = new Parser(grammar)
-  console.log(3)
   parser.lexer = lexer
-  console.log(4)
   const doctests = []
   let doctestIndex = -1
   let state = NO_STATE
   let isClass = false
-  console.log(5)
   // begin multi-line comment
   lexer.addRule(/\/\*/, () => {
     if (state === NO_STATE) {
@@ -82,14 +77,11 @@ export default text => {
 
   // eof
   lexer.addRule(/$/, () => 'EOF')
-  console.log(6)
   parser.parse(text)
-  console.log(7)
   // trim everythhing
   const sanitizedDoctests = doctests.map(({ resultString, stringToEval }) => ({
     resultString: resultString.trim(),
     stringToEval: stringToEval.trim(),
   }))
-  console.log('OK')
   return sanitizedDoctests
 }

--- a/src/doctest_parser.js
+++ b/src/doctest_parser.js
@@ -58,16 +58,32 @@ export default text => {
 
   // ignore multi-line comment start
   // this is a bit naive as it only uses spaces/indentation to cleanse
-  lexer.addRule(/\n\* / && /\r\n\* /, () => {})
-  lexer.addRule(/\n \* / && /\r\n \* /, () => {})
-  lexer.addRule(/\n  \* / && /\r\n  \* /, () => {})
-  lexer.addRule(/\n   \* / && /\r\n   \* /, () => {})
-  lexer.addRule(/\n    \* / && /\r\n    \* /, () => {})
-  lexer.addRule(/\n     \* / && /\r\n     \* /, () => {})
-  lexer.addRule(/\n      \* / && /\r\n      \* /, () => {})
+  lexer.addRule(/\n\* /, () => {})
+  lexer.addRule(/\r\n\* /, () => {})
+  lexer.addRule(/\n \* /, () => {})
+  lexer.addRule(/\r\n \* /, () => {})
+  lexer.addRule(/\n  \* /, () => {})
+  lexer.addRule(/\r\n  \* /, () => {})
+  lexer.addRule(/\n   \* /, () => {})
+  lexer.addRule(/\r\n   \* /, () => {})
+  lexer.addRule(/\n    \* /, () => {})
+  lexer.addRule(/\r\n    \* /, () => {})
+  lexer.addRule(/\n     \* /, () => {})
+  lexer.addRule(/\r\n     \* /, () => {})
+  lexer.addRule(/\n      \* /, () => {})
+  lexer.addRule(/\r\n      \* /, () => {})
 
   // add chars to appropriate section
-  lexer.addRule(/\n|./ && /\r\n|./, lexme => {
+  
+  lexer.addRule(/\n|./, lexme => {
+    if (state === IN_EXAMPLE) {
+      doctests[doctestIndex].resultString += lexme
+    } else if (state === IN_RETURN_VALUE) {
+      doctests[doctestIndex].stringToEval += lexme
+    }
+  })
+
+  lexer.addRule(/\r\n|./, lexme => {
     if (state === IN_EXAMPLE) {
       doctests[doctestIndex].resultString += lexme
     } else if (state === IN_RETURN_VALUE) {

--- a/src/doctest_parser.js
+++ b/src/doctest_parser.js
@@ -16,15 +16,18 @@ const grammar = {
 
 export default text => {
   // lexer parser setup
+  console.log(1)
   const lexer = new Lexer()
+  console.log(2)
   const parser = new Parser(grammar)
+  console.log(3)
   parser.lexer = lexer
-
+  console.log(4)
   const doctests = []
   let doctestIndex = -1
   let state = NO_STATE
   let isClass = false
-
+  console.log(5)
   // begin multi-line comment
   lexer.addRule(/\/\*/, () => {
     if (state === NO_STATE) {
@@ -60,16 +63,16 @@ export default text => {
 
   // ignore multi-line comment start
   // this is a bit naive as it only uses spaces/indentation to cleanse
-  lexer.addRule(/\n\* /, () => {})
-  lexer.addRule(/\n \* /, () => {})
-  lexer.addRule(/\n  \* /, () => {})
-  lexer.addRule(/\n   \* /, () => {})
-  lexer.addRule(/\n    \* /, () => {})
-  lexer.addRule(/\n     \* /, () => {})
-  lexer.addRule(/\n      \* /, () => {})
+  lexer.addRule(/\r\n\* /, () => {})
+  lexer.addRule(/\r\n \* /, () => {})
+  lexer.addRule(/\r\n  \* /, () => {})
+  lexer.addRule(/\r\n   \* /, () => {})
+  lexer.addRule(/\r\n    \* /, () => {})
+  lexer.addRule(/\r\n     \* /, () => {})
+  lexer.addRule(/\r\n      \* /, () => {})
 
   // add chars to appropriate section
-  lexer.addRule(/\n|./, lexme => {
+  lexer.addRule(/\r\n|./, lexme => {
     if (state === IN_EXAMPLE) {
       doctests[doctestIndex].resultString += lexme
     } else if (state === IN_RETURN_VALUE) {
@@ -79,14 +82,14 @@ export default text => {
 
   // eof
   lexer.addRule(/$/, () => 'EOF')
-
+  console.log(6)
   parser.parse(text)
-
+  console.log(7)
   // trim everythhing
   const sanitizedDoctests = doctests.map(({ resultString, stringToEval }) => ({
     resultString: resultString.trim(),
     stringToEval: stringToEval.trim(),
   }))
-
+  console.log('OK')
   return sanitizedDoctests
 }

--- a/src/safe_eval.js
+++ b/src/safe_eval.js
@@ -1,9 +1,12 @@
+import { Console } from 'console'
 /* eslint no-eval: "off", no-console: "off" */
 import path from 'path'
 
 export const evalExpression = (evalString, filePath) => {
   try {
+    console.log("EVAL EXPRESSION")
     const code = `require('${filePath}').${evalString}`
+    console.log(code)
     const result = eval(code)
     return { result }
   } catch (error) {
@@ -22,7 +25,7 @@ export const evalValue = evalString => {
 
 export default ({ resultString, stringToEval }, filePath, instance) => {
   const fullFilePath = path.join(process.cwd(), filePath)
-
+  console.log(fullFilePath)
   if (!instance) {
     const actual = evalExpression(resultString, fullFilePath)
     const expected = evalValue(stringToEval)

--- a/src/safe_eval.js
+++ b/src/safe_eval.js
@@ -3,7 +3,7 @@ import path from 'path'
 
 export const evalExpression = (evalString, filePath) => {
   try {
-    if (filePath != null) filePath = filePath.replace(/\\/g,'/');
+    if (filePath !== undefined) filePath = filePath.replace(/\\/g,'/');
     const code = `require('${filePath}').${evalString}`
     const result = eval(code)
     return { result }

--- a/src/safe_eval.js
+++ b/src/safe_eval.js
@@ -1,12 +1,10 @@
-import { Console } from 'console'
 /* eslint no-eval: "off", no-console: "off" */
 import path from 'path'
 
 export const evalExpression = (evalString, filePath) => {
   try {
-    console.log("EVAL EXPRESSION")
+    if (filePath != null) filePath = filePath.replace(/\\/g,'/');
     const code = `require('${filePath}').${evalString}`
-    console.log(code)
     const result = eval(code)
     return { result }
   } catch (error) {
@@ -25,7 +23,6 @@ export const evalValue = evalString => {
 
 export default ({ resultString, stringToEval }, filePath, instance) => {
   const fullFilePath = path.join(process.cwd(), filePath)
-  console.log(fullFilePath)
   if (!instance) {
     const actual = evalExpression(resultString, fullFilePath)
     const expected = evalValue(stringToEval)

--- a/test/doctest_test.js
+++ b/test/doctest_test.js
@@ -6,15 +6,11 @@ const SAMPLE_PASSING_MODULE_PATH = './test/support/sample_passing_module.js'
 const SAMPLE_PASSING_CLASS_PATH = './test/support/sample_passing_class.js'
 const SAMPLE_FAILING_MODULE_PATH = './test/support/sample_failing_module.js'
 const SAMPLE_ERROR_MODULE_PATH = './test/support/sample_error_module.js'
-console.log(SAMPLE_PASSING_MODULE_PATH);
 const { Arithmetic } = require('./support/sample_passing_class.js')
 
 describe('passing doctest', () => {
-  console.log('here')
   doctest(SAMPLE_PASSING_MODULE_PATH)
-  console.log('here 2')
   doctest(SAMPLE_PASSING_CLASS_PATH, { instance: new Arithmetic() })
-  console.log('here 3')
 })
 
 describe('failing doctest', () => {

--- a/test/doctest_test.js
+++ b/test/doctest_test.js
@@ -6,12 +6,15 @@ const SAMPLE_PASSING_MODULE_PATH = './test/support/sample_passing_module.js'
 const SAMPLE_PASSING_CLASS_PATH = './test/support/sample_passing_class.js'
 const SAMPLE_FAILING_MODULE_PATH = './test/support/sample_failing_module.js'
 const SAMPLE_ERROR_MODULE_PATH = './test/support/sample_error_module.js'
-
+console.log(SAMPLE_PASSING_MODULE_PATH);
 const { Arithmetic } = require('./support/sample_passing_class.js')
 
 describe('passing doctest', () => {
+  console.log('here')
   doctest(SAMPLE_PASSING_MODULE_PATH)
+  console.log('here 2')
   doctest(SAMPLE_PASSING_CLASS_PATH, { instance: new Arithmetic() })
+  console.log('here 3')
 })
 
 describe('failing doctest', () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Resolve compatibility issue with windows machine

## What is the current behavior?

https://github.com/supabase/doctest-js/issues/24
- module is not correctly parsing the path on windows
- POSIX style newline `\n` is not compatible with windows machine thus it keep returning `Unexpected character at index n`
- failing tests on windows machine because of ^

## What is the new behavior?

- added `lexer.addRule('\r\n')`
- fix windows filepath parsing. replace back-slash `\` to forward-slash `/` when loading filepath into `evalExpression(evalString, filePath)` 
- `doctest()` and project's tests suite should work on windows machine.

## Additional context

>playground test result using README example and Jest:

![image](https://user-images.githubusercontent.com/24191952/94786824-11350600-0404-11eb-831c-50e35c437d4a.png)
